### PR TITLE
6 remove client name from update client call

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,27 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "init",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "main.go",
+            "args": [
+                "init",
+                "--host", "http://0.0.0.0:8081",
+                "-p", "admin",
+                "-u", "admin",
+                "-r", "master"
+            ]
+        },
+        {
             "name": "create client",
             "type": "go",
             "request": "launch",
             "mode": "auto",
             "program": "main.go",
             "args": [
-                "create", "client", "thisone"
+                "create", "client", "testclient"
             ]
         },
         {
@@ -21,7 +35,7 @@
             "mode": "auto",
             "program": "main.go",
             "args": [
-                "update", "client", "--json", "examples/update_client.json", "arg0here"
+                "update", "client", "--json", "examples/myclient.json"
             ]
         }
     ]

--- a/cmd/update_client.go
+++ b/cmd/update_client.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"log"
 	"os"
 
 	"github.com/Nerzal/gocloak/v11"
@@ -16,6 +17,9 @@ var updateClientCmd = &cobra.Command{
 
 Example: keycloak-commander update client --json /path/to/file.json`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 0 {
+			log.Fatalf("0 arguments expected, got %d", len(args))
+		}
 		jsonFilename := cmd.Flag("json").Value.String()
 		filePayload, err := os.ReadFile(jsonFilename)
 		if err != nil {
@@ -25,9 +29,9 @@ Example: keycloak-commander update client --json /path/to/file.json`,
 
 		err = json.Unmarshal(filePayload, clientRepresentation)
 		if err != nil {
-			panic(err)
+			log.Fatal("There was an error loading the JSON file as a ClientRepresentation: ", err)
 		}
-		KeycloakCommander.UpdateClient(args[0], clientRepresentation)
+		KeycloakCommander.UpdateClient(clientRepresentation)
 	},
 }
 

--- a/keycloak/keycloak.go
+++ b/keycloak/keycloak.go
@@ -50,11 +50,11 @@ func (kc *KeycloakCommander) CreateClient(clientName string) {
 	log.Println(client)
 }
 
-func (kc *KeycloakCommander) UpdateClient(clientName string, updatedClient *gocloak.Client) {
+func (kc *KeycloakCommander) UpdateClient(updatedClient *gocloak.Client) {
 
 	err := kc.client.UpdateClient(kc.context, kc.accessToken, kc.Realm, *updatedClient)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
-	log.Printf("Client updated: %s\n", clientName)
+	log.Printf("Client updated: %s\n", *updatedClient.ClientID)
 }


### PR DESCRIPTION
It turns out, the client name is specified in the ClientRepresentation that is passed in, so I actually needed to remove the client name